### PR TITLE
add reporting

### DIFF
--- a/.github/workflows/zarr-dev.yml
+++ b/.github/workflows/zarr-dev.yml
@@ -42,14 +42,10 @@ jobs:
         run: |
             python test/test_read_all.py
 
-      - name: Archive HTML test report
+      - name: Archive test report artifacts
         uses: actions/upload-artifact@v2
         with:
           name: test-report-html
-          path: report.html
-
-      - name: Archive Markdown test report
-        uses: actions/upload-artifact@v2
-        with:
-          name: test-report-md
-          path: report.md
+          path: |
+              report.md
+              report.html

--- a/.github/workflows/zarr-dev.yml
+++ b/.github/workflows/zarr-dev.yml
@@ -36,3 +36,20 @@ jobs:
       - name: Run tests
         shell: bash -l {0}
         run: make
+
+      - name: Generate Report
+        shell: bash -l {0}
+        run: |
+            python test/test_read_all.py
+
+      - name: Archive HTML test report
+        uses: actions/upload-artifact@v2
+        with:
+          name: test-report-html
+          path: report.html
+
+      - name: Archive Markdown test report
+        uses: actions/upload-artifact@v2
+        with:
+          name: test-report-md
+          path: report.md

--- a/.github/workflows/zarr-dev.yml
+++ b/.github/workflows/zarr-dev.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Archive test report artifacts
         uses: actions/upload-artifact@v2
         with:
-          name: test-report-html
+          name: test-report
           path: |
               report.md
               report.html

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 target*
 __pycache__/
 node_modules/
+# ignore test summary reports
+report.*

--- a/Makefile
+++ b/Makefile
@@ -36,3 +36,7 @@ xtensor_zarr: data/reference_image.png
 data: n5java pyn5 z5py zarr js xtensor_zarr zarrita
 
 .PHONY: test
+
+.PHONY: report
+report: data
+	python test/test_read_all.py

--- a/environment.yml
+++ b/environment.yml
@@ -17,6 +17,8 @@ dependencies:
   - pytest
   - zarr >= 2.4.0
   - pip
+  - pandas
+  - tabulate
   - pip:
       - pyn5
       - git+https://github.com/grlee77/zarrita.git@codec_update

--- a/test/test_read_all.py
+++ b/test/test_read_all.py
@@ -125,7 +125,6 @@ def create_params():
 
 
 argnames, params, ids = create_params()
-print(params)
 
 
 @pytest.mark.parametrize(argnames, params, ids=ids)
@@ -141,3 +140,169 @@ def test_correct_read(fmt, writing_library, reading_library, codec):
     test = read_fn(fpath, codec)
     assert test.shape == reference.shape
     assert np.allclose(test, reference)
+
+
+def tabulate_test_results(params, per_codec_tables=False):
+    all_results = {}
+
+    for fmt, writing_library, reading_library, codec in params:
+        reference = imread(DATA_DIR / "reference_image.png")
+        fpath = DATA_DIR / f"{writing_library}{EXTENSIONS[fmt]}"
+        read_fn = {
+            "zarr": read_with_zarr,
+            "pyn5": read_with_pyn5,
+            "z5py": read_with_z5py,
+            "zarrita": read_with_zarrita,
+        }[reading_library]
+
+        fail_type = None
+        try:
+            test = read_fn(fpath, codec)
+        except Exception as e:
+            fail_type = f"{type(e).__name__}: {e}"
+
+        if fail_type is None:
+            result = test.shape == reference.shape
+            result = result and np.allclose(test, reference)
+        else:
+            result = fail_type
+
+        if per_codec_tables:
+            table_key = fmt, codec
+            inner_key = (writing_library, reading_library)
+        else:
+            table_key = fmt
+            inner_key = (', '.join((writing_library, codec)), reading_library)
+
+        if table_key not in all_results:
+            all_results[table_key] = {}
+
+        all_results[table_key][inner_key] = result
+
+    return all_results
+
+
+def result_to_table(result, use_emojis=True, fmt='md'):
+    """Generate a markdown style table
+
+    Parmaters
+    ---------
+    result : dict
+        Dict where the keys are a 2-tuple of strings indicating the
+        (index, column) labels and the values are the value at that location.
+    use_emojis : bool, optional
+        If True, emoji checkmarks will be used within the table. Otherwise
+        plain text entries (e.g. SUCCESS, FAILURE) are used instead.
+    fmt : {'md', 'html'}
+        'md' and 'html' give Markdown and HTML format outputs, respectively.
+
+    Returns
+    -------
+    table : str
+        str containing the table in Markdown format
+    """
+    import pandas as pd
+
+    # e.g res = all_results[('zarr', 'raw')]
+    df = pd.DataFrame()
+    writers = sorted(list(set([k[0] for k in result.keys()])))
+    readers = sorted(list(set([k[1] for k in result.keys()])))
+    df = pd.DataFrame(index=writers, columns=readers, dtype=str)
+    df[:] = '----'
+    if fmt == 'md':
+        fail_str = ':x:' if use_emojis else 'FAILED'
+        pass_str = ':heavy_check_mark:' if use_emojis else 'PASSED'
+    elif fmt == 'html':
+        fail_str = '&#10060;'  # HTML code for cross mark
+        pass_str = '&#10004;'  # HTML code for heavy check mark
+    else:
+        fail_str = 'FAILED'
+        pass_str = 'PASSED'
+
+    for k, v in result.items():
+        # df[k[1]][k[0]] = f"{v}"
+        if v not in [True, False]:
+            df_val = fail_str + f": {v}"
+        else:
+            if use_emojis:
+                df_val = pass_str if v else f'{fail_str}: mismatched'
+            else:
+                df_val = pass_str if v else fail_str
+        df.at[k[0], k[1]] = df_val\
+
+    if fmt == 'html':
+        table = df.to_html()
+        # undo any replacements of & with &amp;
+        return table.replace(r'&amp;', '&')
+    else:
+        return df.to_markdown()
+
+
+def concatenate_tables(all_results, use_emojis=True, fmt='md'):
+    """Generate a report containing markdown-style tables
+
+    Parmaters
+    ---------
+    all_results : dict
+        Dict of test results as returned by generate_report
+    use_emojis : bool, optional
+        If True, emoji checkmarks will be used within the table. Otherwise
+        plain text entries (e.g. SUCCESS, FAILURE) are used instead.
+    fmt : {'md', 'html'}
+        'md' and 'html' give Markdown and HTML format outputs, respectively.
+
+    Returns
+    -------
+    report : str
+        str containing the report in Markdown format
+    """
+    if fmt == 'html':
+        header = """
+            <!DOCTYPE html>
+            <html>
+            <head>
+            <meta charset="UTF-8">\n\n
+        """
+        report = '\n'.join(h.lstrip(' ') for h in header.split('\n'))
+
+
+        for table_name, res in all_results.items():
+            report += f'<p><h1>{table_name}</h1></p>\n'
+            report += result_to_table(res, use_emojis=use_emojis, fmt=fmt)
+            report += '<br><br>\n\n\n'
+
+        footer = """
+            </head>
+            <body>
+        """
+        report += '\n'.join(f.lstrip(' ') for f in footer.split('\n'))
+
+    elif fmt == 'md':
+        report = ''
+        for table_name, res in all_results.items():
+            report += f'# {table_name} Results\n'
+            report += result_to_table(res, use_emojis=use_emojis, fmt=fmt)
+            report += '\n\n\n'
+    else:
+        raise ValueError(f"unkown fmt: '{fmt}'. Must be 'md' or 'html'")
+
+    return report
+
+
+if __name__ == '__main__':
+
+
+    all_results = tabulate_test_results(params)
+
+    # save version with checkmark emojis to disk
+    report_md = concatenate_tables(all_results, use_emojis=True, fmt='md')
+    with open('report.md', 'wt') as f:
+        f.writelines(report_md)
+
+    # save HTML version to disk
+    report_html = concatenate_tables(all_results, fmt='html')
+    with open('report.html', 'wt') as f:
+        f.writelines(report_html)
+
+    # print version with plain text entries to the console
+    print(concatenate_tables(all_results, use_emojis=False, fmt='md'))


### PR DESCRIPTION
This likely not in its final, desired form, but I wanted to start thinking about how to report results. This PR generates tables that can be rendered in Markdown or HTML. Currently this is done via calling the test script as a regular python script, but that was just done for expediency and can be changed to some other desired way of generating these.

A question is how to most usefully present results. Currently, each format (zarr v2, zarr v3, N5) has a separate table where rows correspond to `(writer, codec)` and columns correspond to the reader with check marks indicating success and red X indicating failures. The Markdown output renders as follows (with option to avoid the emoji check/x marks if printing to the terminal):

# zarr Results
|                     | z5py               | zarr               |
|:--------------------|:-------------------|:-------------------|
| js, blosc           | :heavy_check_mark: | :heavy_check_mark: |
| js, gzip            | :heavy_check_mark: | :heavy_check_mark: |
| js, raw             | :heavy_check_mark: | :heavy_check_mark: |
| js, zlib            | :heavy_check_mark: | :heavy_check_mark: |
| xtensor_zarr, blosc | :heavy_check_mark: | :heavy_check_mark: |
| xtensor_zarr, gzip  | :heavy_check_mark: | :heavy_check_mark: |
| xtensor_zarr, raw   | :heavy_check_mark: | :heavy_check_mark: |
| xtensor_zarr, zlib  | :heavy_check_mark: | :heavy_check_mark: |
| z5py, blosc         | :heavy_check_mark: | :heavy_check_mark: |
| z5py, gzip          | :heavy_check_mark: | :heavy_check_mark: |
| z5py, raw           | :heavy_check_mark: | :heavy_check_mark: |
| z5py, zlib          | :heavy_check_mark: | :heavy_check_mark: |
| zarr, blosc         | :heavy_check_mark: | :heavy_check_mark: |
| zarr, gzip          | :heavy_check_mark: | :heavy_check_mark: |
| zarr, raw           | :heavy_check_mark: | :heavy_check_mark: |
| zarr, zlib          | :heavy_check_mark: | :heavy_check_mark: |


# N5 Results
|                | pyn5               | z5py               | zarr               |
|:---------------|:-------------------|:-------------------|:-------------------|
| n5-java, bzip2 | :heavy_check_mark: | ----               | ----               |
| n5-java, gzip  | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: |
| n5-java, raw   | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: |
| pyn5, bzip2    | :heavy_check_mark: | ----               | ----               |
| pyn5, gzip     | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: |
| pyn5, raw      | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: |
| z5py, gzip     | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: |
| z5py, raw      | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: |
| zarr, gzip     | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: |
| zarr, raw      | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: |


# zarr-v3 Results
|                | zarrita            |
|:---------------|:-------------------|
| zarrita, blosc | :heavy_check_mark: |
| zarrita, gzip  | :heavy_check_mark: |
| zarrita, raw   | :heavy_check_mark: |
| zarrita, zlib  | :heavy_check_mark: |
