### PR TITLE
avoid xtensor version with known segfault

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -7,6 +7,7 @@ dependencies:
   - make
   - cmake
   - xtensor-zarr=0.0.3=*_1
+  - xtensor != 0.23.5
   - openimageio
   - zlib
   - blosc


### PR DESCRIPTION
Segfault on `xtensor-zarr` data generation was observed with xtensor 0.23.5 and xtensor-io 0.12.5 in both #30 and #31.

No segfault occurs on the previous xtensor 0.23.4 / tensor-io 0.12.4