### PR TITLE
Add nested data generation and tests (zarr-python and zarrita)

### DIFF
--- a/generate_data/generate_zarr.py
+++ b/generate_data/generate_zarr.py
@@ -13,11 +13,17 @@ COMPRESSION_OPTIONS = {"blosc": {"cname": "lz4"}}
 
 
 # TODO use more compressors from numcodecs and more blosc filter_ids
-def generate_zarr_format(compressors=['gzip', 'blosc', 'zlib', None]):
-    path = 'data/zarr.zr'
+def generate_zarr_format(compressors=['gzip', 'blosc', 'zlib', None],
+                         nested=False):
+    if nested:
+        path = 'data/zarr.zr'
+        store = path
+    else:
+        path = 'data/zarr_nested.zr'
+        store = zarr.storage.FSStore(path, key_separator='/', auto_mkdir=True)
     im = astronaut()
 
-    f = zarr.open(path, mode='w')
+    f = zarr.open(store, mode='w')
     for compressor in compressors:
         copts = COMPRESSION_OPTIONS.get(compressor, {})
         if compressor is None:
@@ -32,10 +38,9 @@ def generate_zarr_format(compressors=['gzip', 'blosc', 'zlib', None]):
 
 
 def generate_n5_format(compressors=['gzip', None]):
-    path = 'data/zarr.n5'
     im = astronaut()
 
-    f = zarr.open(path, mode='w')
+    f = zarr.open('data/zarr.n5', mode='w')
     for compressor in compressors:
         name = compressor if compressor is not None else 'raw'
         compressor_impl = STR_TO_COMPRESSOR[compressor]() if compressor is not None else None
@@ -44,5 +49,6 @@ def generate_n5_format(compressors=['gzip', None]):
 
 
 if __name__ == '__main__':
-    generate_zarr_format()
+    for nested in [False, True]:
+        generate_zarr_format(nested=nested)
     generate_n5_format()

--- a/generate_data/generate_zarrita.py
+++ b/generate_data/generate_zarrita.py
@@ -12,10 +12,16 @@ STR_TO_COMPRESSOR = {
 COMPRESSION_OPTIONS = {"blosc": {"cname": "lz4"}}
 
 
-def generate_zr3_format(compressors=['gzip', 'blosc', 'zlib', None]):
+def generate_zr3_format(compressors=['gzip', 'blosc', 'zlib', None],
+                        nested=True):
     im = astronaut()
-
-    h = zarrita.create_hierarchy('data/zarrita.zr3')
+    if nested:
+        chunk_separator = '/'
+        fname = 'data/zarrita_nested.zr3'
+    else:
+        chunk_separator = '.'
+        fname = 'data/zarrita.zr3'
+    h = zarrita.create_hierarchy(fname)
     for compressor in compressors:
         copts = COMPRESSION_OPTIONS.get(compressor, {})
         if compressor is None:
@@ -26,9 +32,11 @@ def generate_zr3_format(compressors=['gzip', 'blosc', 'zlib', None]):
             name = compressor
         compressor_impl = STR_TO_COMPRESSOR[compressor](**copts) if compressor is not None else None
         a = h.create_array('/' + name, shape=im.shape, chunk_shape=CHUNKS,
-                           dtype=im.dtype, compressor=compressor_impl)
+                           chunk_separator=chunk_separator, dtype=im.dtype,
+                           compressor=compressor_impl)
         a[...] = im
 
 
 if __name__ == '__main__':
-    generate_zr3_format()
+    for nested in [False, True]:
+        generate_zr3_format(nested=nested)

--- a/test/test_read_all.py
+++ b/test/test_read_all.py
@@ -249,7 +249,7 @@ def result_to_table(result, use_emojis=True, fmt='md'):
                 df_val = pass_str if v else f'{fail_str}: mismatched'
             else:
                 df_val = pass_str if v else fail_str
-        df.at[k[0], k[1]] = df_val\
+        df.at[k[0], k[1]] = df_val
 
     if fmt == 'html':
         table = df.to_html()

--- a/test/test_read_all.py
+++ b/test/test_read_all.py
@@ -154,8 +154,8 @@ def _get_read_fn(fmt, writing_library, reading_library, nested_str):
 
 @pytest.mark.parametrize(argnames, params, ids=ids)
 def test_correct_read(fmt, writing_library, reading_library, codec, nested):
-    if nested and reading_library not in ['zarr', 'zarrita']:
-        pytest.skip("nested read not implemented")
+    if nested and reading_library == 'z5py':
+        pytest.skip("nested read not implemented in z5py")
 
     reference = imread(DATA_DIR / "reference_image.png")
     nested_str = "_nested" if nested else ""

--- a/test/test_read_all.py
+++ b/test/test_read_all.py
@@ -149,7 +149,7 @@ def _get_read_fn(fmt, writing_library, reading_library):
 
 @pytest.mark.parametrize(argnames, params, ids=ids)
 def test_correct_read(fmt, writing_library, reading_library, codec, nested):
-    if nested and reading_library != 'zarr':
+    if nested and reading_library not in ['zarr', 'zarrita']:
         pytest.skip("nested read not implemented")
 
     reference = imread(DATA_DIR / "reference_image.png")

--- a/test/test_read_all.py
+++ b/test/test_read_all.py
@@ -170,11 +170,13 @@ def tabulate_test_results(params, per_codec_tables=False):
     reference = imread(DATA_DIR / "reference_image.png")
 
     all_results = {}
-    for fmt, writing_library, reading_library, codec in params:
-        fpath, read_fn = _get_read_fn(fmt, writing_library, reading_library)
+    for fmt, writing_library, reading_library, codec, nested in params:
+        nested_str = "_nested" if nested else ""
+        fpath, read_fn = _get_read_fn(fmt, writing_library, reading_library,
+                                      nested_str)
         fail_type = None
         try:
-            test = read_fn(fpath, codec)
+            test = read_fn(fpath, codec, nested)
         except Exception as e:
             fail_type = f"{type(e).__name__}: {e}"
 
@@ -184,12 +186,14 @@ def tabulate_test_results(params, per_codec_tables=False):
         else:
             result = fail_type
 
+        nstr = 'nested' if nested else 'flat'
         if per_codec_tables:
             table_key = fmt, codec
-            inner_key = (writing_library, reading_library)
+            inner_key = (', '.join(writing_library, nstr), reading_library)
         else:
             table_key = fmt
-            inner_key = (', '.join((writing_library, codec)), reading_library)
+            inner_key = (', '.join((writing_library, codec, nstr)),
+                         reading_library)
 
         if table_key not in all_results:
             all_results[table_key] = {}


### PR DESCRIPTION
This PR adds nested data generation and reads with zarr-python (v2) and zarrita (v3).

z5py does not seem to support reading the nested data from zarr-python so I marked it as "skipped" in the test suite. It will currently show up as "FAILED: mismatch" in the test report tables.

I was originally using `zarr.storage.FSStore` to read the nested data with zarr-python in the tests, but this was failing due to zarr-developers/zarr#717. I switched it to NestedDirectoryStore, which passes.

For the report, row names now have ", flat" or ", nested" appended to indicate which format was read.

