### PR TITLE
use dimension_separator in zarr-python data generation script

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -16,7 +16,7 @@ dependencies:
   - python == 3.7.9
   - scikit-image
   - pytest
-  - zarr >= 2.4.0
+  - zarr >= 2.8.0
   - pip
   - pandas
   - tabulate

--- a/generate_data/generate_zarr.py
+++ b/generate_data/generate_zarr.py
@@ -20,7 +20,7 @@ def generate_zarr_format(compressors=['gzip', 'blosc', 'zlib', None]):
         (False, zarr.storage.FSStore, {}),
         (True, zarr.storage.NestedDirectoryStore, {}),
         (True, zarr.storage.FSStore,
-         {'key_separator': '/', 'auto_mkdir': True}),
+         {'dimension_separator': '/', 'auto_mkdir': True}),
     ]:
 
         nested_str = '_nested' if nested else '_flat'

--- a/test/test_read_all.py
+++ b/test/test_read_all.py
@@ -73,7 +73,7 @@ def read_with_zarr(fpath, ds_name, nested):
         if nested:
             if 'FSStore' in str(fpath):
                 store = zarr.storage.FSStore(
-                    os.fspath(fpath), key_separator='/', mode='r'
+                    os.fspath(fpath), dimension_separator='/', mode='r'
                 )
             else:
                 store = zarr.storage.NestedDirectoryStore(os.fspath(fpath))


### PR DESCRIPTION
This PR removes use of the `key_separator` kwarg from the calls to FSStore, using the new `dimension_separator` argument to `create_dataset` instead.
