### PR TITLE
xtensor-zarr: test both flat and nested cases across versions

### DIFF
--- a/generate_data/xtensor_zarr/src/main.cpp
+++ b/generate_data/xtensor_zarr/src/main.cpp
@@ -16,7 +16,7 @@ int main(int argc, char** argv)
     if (argc == 1)
     {
         namespace fs = ghc::filesystem;
-        std::string hier_path = "../../../data/xtensor_zarr.zr";
+        std::string hier_path_base = "../../../data/xtensor_zarr";
         const auto img = load_image("../../../data/reference_image.png");
 
         const auto& s = img.shape();
@@ -31,42 +31,68 @@ int main(int argc, char** argv)
         {
             if (v == 3)
             {
-                hier_path += "3";
                 zarr_version[0] = '3';
                 data_type ++;
             }
-            fs::remove_all(hier_path);
-            fs::create_directory(hier_path);
-            auto h = create_zarr_hierarchy(hier_path.c_str(), zarr_version);
-            auto g = h.create_group("/");
 
-            // raw
-            xzarr_create_array_options<xio_binary_config> raw_options;
-            raw_options.fill_value = 0;
-            zarray z_raw = h.create_array("/raw", shape, chunk_shape, data_type, raw_options);
-            noalias(z_raw) = img;
+            std::vector<bool> nested_values = {false, true};
+            for (bool nested : nested_values)
+            {
+                std::string hier_path;
+                char *chunk_separator;
 
-            // gzip
-            xzarr_create_array_options<xio_gzip_config> gzip_options;
-            gzip_options.fill_value = 0;
-            zarray z_gzip = h.create_array("/gzip", shape, chunk_shape, data_type, gzip_options);
-            noalias(z_gzip) = img;
+                if (nested)
+                {
+                    hier_path = hier_path_base + "_nested.zr";
+                    chunk_separator = (char *)"/";
+                }
+                else
+                {
+                    hier_path = hier_path_base + "_flat.zr";
+                    chunk_separator = (char *)".";
+                }
+                if (v == 3)
+                {
+                    hier_path += '3';
+                }
 
-            // zlib
-            xzarr_create_array_options<xio_zlib_config> zlib_options;
-            zlib_options.fill_value = 0;
-            zarray z_zlib = h.create_array("/zlib", shape, chunk_shape, data_type, zlib_options);
-            noalias(z_zlib) = img;
+                fs::remove_all(hier_path);
+                fs::create_directory(hier_path);
+                auto h = create_zarr_hierarchy(hier_path.c_str(), zarr_version);
+                auto g = h.create_group("/");
 
-            // blosc
-            xio_blosc_config blosc_config;
-            blosc_config.cname = "lz4";
-            xzarr_create_array_options<xio_blosc_config> blosc_options;
-            blosc_options.fill_value = 0;
-            blosc_options.compressor = blosc_config;
-            auto g_blosc = h.create_group("/blosc/");
-            zarray z_blosc_lz4 = h.create_array("/blosc/lz4", shape, chunk_shape, data_type, blosc_options);
-            noalias(z_blosc_lz4) = img;
+                // raw
+                xzarr_create_array_options<xio_binary_config> raw_options;
+                raw_options.fill_value = 0;
+                raw_options.chunk_separator = *chunk_separator;
+                zarray z_raw = h.create_array("/raw", shape, chunk_shape, data_type, raw_options);
+                noalias(z_raw) = img;
+
+                // gzip
+                xzarr_create_array_options<xio_gzip_config> gzip_options;
+                gzip_options.fill_value = 0;
+                gzip_options.chunk_separator = *chunk_separator;
+                zarray z_gzip = h.create_array("/gzip", shape, chunk_shape, data_type, gzip_options);
+                noalias(z_gzip) = img;
+
+                // zlib
+                xzarr_create_array_options<xio_zlib_config> zlib_options;
+                zlib_options.fill_value = 0;
+                zlib_options.chunk_separator = *chunk_separator;
+                zarray z_zlib = h.create_array("/zlib", shape, chunk_shape, data_type, zlib_options);
+                noalias(z_zlib) = img;
+
+                // blosc
+                xio_blosc_config blosc_config;
+                blosc_config.cname = "lz4";
+                xzarr_create_array_options<xio_blosc_config> blosc_options;
+                blosc_options.fill_value = 0;
+                blosc_options.compressor = blosc_config;
+                blosc_options.chunk_separator = *chunk_separator;
+                auto g_blosc = h.create_group("/blosc/");
+                zarray z_blosc_lz4 = h.create_array("/blosc/lz4", shape, chunk_shape, data_type, blosc_options);
+                noalias(z_blosc_lz4) = img;
+            }
         }
     }
     else


### PR DESCRIPTION
This PR updates the xtensor-zarr data generation program to test both flat and nested (dimension_separator = "." and "/") formats for zarr-v2 and zarr-v3.

cc @davidbrochart : please check that the C++ style looks reasonable to you
