### PR TITLE
Evaluate zarr-developers/zarr-python#773

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -13,10 +13,10 @@ dependencies:
   - python == 3.7.9
   - scikit-image
   - pytest
-  - zarr >= 2.8.3
   - pip
   - pandas
   - tabulate
   - pip:
       - pyn5
       - git+https://github.com/grlee77/zarrita.git@codec_update
+      - git+https://github.com/joshmoore/zarr-python.git@fix-dstore


### PR DESCRIPTION
zarr-developers/zarr-python#773 attempts to fix [confusion](https://github.com/zarr-developers/zarr-python/issues/769) around dimension_separators, incl. for the N5 implementation.