### PR TITLE
Drop `@master` from `pip install`

### DIFF
--- a/.github/workflows/zarr-dev.yml
+++ b/.github/workflows/zarr-dev.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Install zarr dev
         shell: bash -l {0}
         run: |
-          python -m pip install git+https://github.com/zarr-developers/zarr-python.git@master
+          python -m pip install git+https://github.com/zarr-developers/zarr-python.git
 
       - name: Run tests
         shell: bash -l {0}


### PR DESCRIPTION
Partially addresses ( https://github.com/zarr-developers/community/issues/44 )

As `pip install` already installs from `HEAD`, there is no need to specify `master` in the command. So drop it.